### PR TITLE
Actionsが落ちてるので修正(Close #35)

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup chromedriver
         run: |
-          google-chrome --version | sed -e 's/[^0-9\.]//g' | { read version; curl https://chromedriver.storage.googleapis.com/"$version"/chromedriver_linux64.zip --output ./chromedriver_linux64.zip; }
+          MAIN_CHROME_VERSION=$(google-chrome --version | sed -r 's/^[^0-9]*([0-9]*).*$/\1/g')
+          LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$MAIN_CHROME_VERSION)
+          curl https://chromedriver.storage.googleapis.com/$LATEST_VERSION/chromedriver_linux64.zip --output ./chromedriver_linux64.zip
           unzip chromedriver_linux64.zip
       - name: Setup JDK 11
         uses: actions/setup-java@v2


### PR DESCRIPTION
## 対応
* `google-chrome --version`で出るバージョンがダウンロードできるとは限らなかった
* 下のページからダウンロードできるバージョンを探し、それをダウンロードするように修正
  * https://chromedriver.storage.googleapis.com/
* 具体的には
  * `google-chrome --version`からメジャーバージョンを取得
  * 例えば、メジャーバージョンが`97`のとき、以下のリンクから97系でダウンロードできるバージョンが取得できる
  * `https://chromedriver.storage.googleapis.com/LATEST_RELESE_97`
  * これを使ってドライバーをダウンロードするようにした

## 備考
* ブログの内容も更新しておく
  * https://blog.okaryo.io/20211127-github-actions-scheduled-scraping-task-by-kotlin